### PR TITLE
Added `started()` method for Simulation class

### DIFF
--- a/include/Titan/sim.h
+++ b/include/Titan/sim.h
@@ -105,6 +105,7 @@ public:
 
     double time();
     bool running();
+    bool started();
 
     void printPositions();
 

--- a/src/sim.cu
+++ b/src/sim.cu
@@ -1098,6 +1098,10 @@ bool Simulation::running() {
     return this -> RUNNING;
 }
 
+bool Simulation::started() {
+    return this -> STARTED;
+}
+
 #ifdef RK2
 template <bool step>
 #endif


### PR DESCRIPTION
Similar to running(). started() returns whether the simulation has been started (i.e. either running or being paused at the moment)